### PR TITLE
Support gradient accumulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pytest
 
 ## Data
 
-The preprocessed version of the Sciplex3 and 4i datasets can be downloaded [here](https://polybox.ethz.ch/index.php/s/RAykIMfDl0qCJaM).
+The preprocessed version of the Sciplex3 and 4i datasets can be downloaded [here](https://www.research-collection.ethz.ch/handle/20.500.11850/609681).
 
 
 ## Example usage

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -130,7 +130,6 @@ class ConditionalMongeTrainer(AbstractTrainer):
             self.state_neural_net, grads, current_logs = self.step_fn(
                 self.state_neural_net,
                 grads=grads,
-                step=step,
                 train_batch=train_batch,
                 valid_batch=valid_batch,
                 is_logging_step=is_logging_step,
@@ -171,11 +170,10 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
             return val_tot_loss, loss_logs
 
-        @functools.partial(jax.jit, static_argnums=[5, 6])
+        @functools.partial(jax.jit, static_argnums=[4, 5])
         def step_fn(
             state_neural_net: train_state.TrainState,
             grads: frozen_dict.FrozenDict,
-            step: int,
             train_batch: Dict[str, jnp.ndarray],
             valid_batch: Optional[Dict[str, jnp.ndarray]] = None,
             is_logging_step: bool = False,

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -7,6 +7,14 @@ from typing import Callable, Dict, Iterator, Optional, Tuple
 import jax
 import jax.numpy as jnp
 import optax
+from dotmap import DotMap
+from flax.core import frozen_dict
+from flax.training import train_state
+from flax.training.orbax_utils import save_args_from_target
+from jax.tree_util import tree_map
+from loguru import logger
+from orbax.checkpoint import PyTreeCheckpointer
+
 from cmonge.datasets.conditional_loader import ConditionalDataModule
 from cmonge.evaluate import init_logger_dict, log_mean_metrics, log_metrics
 from cmonge.models.embedding import embed_factory
@@ -17,13 +25,6 @@ from cmonge.trainers.ot_trainer import (
     regularizer_factory,
 )
 from cmonge.utils import create_or_update_logfile, optim_factory
-from dotmap import DotMap
-from flax.core import frozen_dict
-from flax.training import train_state
-from flax.training.orbax_utils import save_args_from_target
-from jax.tree_util import tree_map
-from loguru import logger
-from orbax.checkpoint import PyTreeCheckpointer
 
 
 class ConditionalMongeTrainer(AbstractTrainer):


### PR DESCRIPTION
This PR does:
- [x] Support gradient accumulation in the `ConditionalMongeTrainer`
- [x] Fix #8 by updating the data link in README

The entry point in the config is `model.optim.grad_acc_steps`. If not set, it defaults to 1 recovering the behavior before merging this PR

@DriessenA I would suggest to run the homogenous-MOA experiment in three settings to assess the impact of this PR:
- setting `grad_acc_steps` to 1 in the config, verifying that the performance is roughly identical to now
- setting `grad_acc_steps` to 4 in the config while dividing the current batch size of 512 by 4 which mimics the current setting but mixes conditions within one batch
- setting `grad_acc_steps` to 4 in the config but keeping the batch size at 512 which increases the effective batch size to 2048. I suspect this might be the best overall setting because MongeGap loss requires pretty large batch sizes to work well (for 128 it might be unstable). In this setting we have less gradient steps updates overall, so we might need to compensate by training for more epochs