### PR TITLE
Homogenize checkpointing

### DIFF
--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -8,6 +8,14 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
+from dotmap import DotMap
+from flax.core import frozen_dict
+from flax.training import train_state
+from flax.training.orbax_utils import save_args_from_target
+from jax.tree_util import tree_map
+from loguru import logger
+from orbax.checkpoint import PyTreeCheckpointer
+
 from cmonge.datasets.conditional_loader import ConditionalDataModule
 from cmonge.evaluate import init_logger_dict, log_mean_metrics, log_metrics
 from cmonge.models.embedding import BaseEmbedding, EmbeddingFactory
@@ -18,13 +26,6 @@ from cmonge.trainers.ot_trainer import (
     regularizer_factory,
 )
 from cmonge.utils import create_or_update_logfile, optim_factory
-from dotmap import DotMap
-from flax.core import frozen_dict
-from flax.training import train_state
-from flax.training.orbax_utils import save_args_from_target
-from jax.tree_util import tree_map
-from loguru import logger
-from orbax.checkpoint import PyTreeCheckpointer
 
 
 class ConditionalMongeTrainer(AbstractTrainer):
@@ -51,6 +52,12 @@ class ConditionalMongeTrainer(AbstractTrainer):
         self.setup(datamodule=datamodule)
 
     def setup(self, datamodule: ConditionalDataModule):
+        """
+        Setup function has to be overriden since it is abstract in base.
+
+        Args:
+            datamodule (ConditionalDataModule): The datamodule to be trained on.
+        """
         # setup loss function and regularizer
         fitting_loss_fn = loss_factory[self.config.fitting_loss.name]
         regularizer_fn = regularizer_factory[self.config.regularizer.name]

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -336,10 +336,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
     def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
         if path is None and config is None:
-            logger.error(
-                """Please provide a checkpoint save path
-            either directly or through the config, checkpoint was NOT saved."""
-            )
+            logger.error("Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved.")
         elif path is None:
             path = config.checkpointing_path
 

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -348,7 +348,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
         config: DotMap,
         datamodule: ConditionalDataModule,
         ckpt_path: Path,
-    ) -> None:
+    ) -> Union[ConditionalMongeTrainer, None]:
         try:
             out_class = cls(
                 jobid=jobid,
@@ -361,17 +361,15 @@ class ConditionalMongeTrainer(AbstractTrainer):
                     ckpt_path = config.checkpointing_path
                 else:
                     logger.error(
-                        """Provide checkpointing path either directly or
-                        through the model config"""
+                        "Provide checkpointing path either directly or through the model config"
                     )
-                    return
             checkpointer = PyTreeCheckpointer()
             out_class.state_neural_net = checkpointer.restore(
                 ckpt_path, item=out_class.state_neural_net
             )
             logger.info("Loaded ConditionalMongeTrainer from checkpoint")
             return out_class
-        except:
+        except Exception:
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -336,7 +336,9 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
     def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
         if path is None and config is None:
-            logger.error("Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved.")
+            logger.error(
+                "Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved."
+            )
         elif path is None:
             path = config.checkpointing_path
 

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -378,4 +378,3 @@ class ConditionalMongeTrainer(AbstractTrainer):
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )
-            return

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -8,6 +8,14 @@ import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
+from dotmap import DotMap
+from flax.core import frozen_dict
+from flax.training import train_state
+from flax.training.orbax_utils import save_args_from_target
+from jax.tree_util import tree_map
+from loguru import logger
+from orbax.checkpoint import PyTreeCheckpointer
+
 from cmonge.datasets.conditional_loader import ConditionalDataModule
 from cmonge.evaluate import init_logger_dict, log_mean_metrics, log_metrics
 from cmonge.models.embedding import BaseEmbedding, EmbeddingFactory
@@ -18,13 +26,6 @@ from cmonge.trainers.ot_trainer import (
     regularizer_factory,
 )
 from cmonge.utils import create_or_update_logfile, optim_factory
-from dotmap import DotMap
-from flax.core import frozen_dict
-from flax.training import train_state
-from flax.training.orbax_utils import save_args_from_target
-from jax.tree_util import tree_map
-from loguru import logger
-from orbax.checkpoint import PyTreeCheckpointer
 
 
 class ConditionalMongeTrainer(AbstractTrainer):
@@ -48,6 +49,12 @@ class ConditionalMongeTrainer(AbstractTrainer):
         self.init_model(datamodule=datamodule)
 
     def setup(self, datamodule: ConditionalDataModule):
+        """
+        Setup function has to be overriden since it is abstract in base.
+
+        Args:
+            datamodule (ConditionalDataModule): The datamodule to be trained on.
+        """
         # setup loss function and regularizer
         fitting_loss_fn = loss_factory[self.config.fitting_loss.name]
         regularizer_fn = regularizer_factory[self.config.regularizer.name]

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -334,7 +334,15 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
         create_or_update_logfile(self.logger_path, self.metrics)
 
-    def save_checkpoint(self, path: Path) -> None:
+    def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
+        if path is None and config is None:
+            logger.error(
+                """Please provide a checkpoint save path
+            either directly or through the config, checkpoint was NOT saved."""
+            )
+        elif path is None:
+            path = config.checkpointing_path
+
         ckpt = self.state_neural_net
         checkpointer = PyTreeCheckpointer()
         save_args = save_args_from_target(ckpt)
@@ -349,15 +357,30 @@ class ConditionalMongeTrainer(AbstractTrainer):
         datamodule: ConditionalDataModule,
         ckpt_path: Path,
     ) -> None:
-        out_class = cls(
-            jobid=jobid,
-            logger_path=logger_path,
-            config=config,
-            datamodule=datamodule,
-        )
-        checkpointer = PyTreeCheckpointer()
-        out_class.state_neural_net = checkpointer.restore(
-            ckpt_path, item=out_class.state_neural_net
-        )
-        logger.info("Loaded ConditionalMongeTrainer from checkpoint")
-        return out_class
+        try:
+            out_class = cls(
+                jobid=jobid,
+                logger_path=logger_path,
+                config=config,
+                datamodule=datamodule,
+            )
+            if ckpt_path is None:
+                if len(config.checkpointing_path) > 0:
+                    ckpt_path = config.checkpointing_path
+                else:
+                    logger.error(
+                        """Provide checkpointing path either directly or
+                        through the model config"""
+                    )
+                    return
+            checkpointer = PyTreeCheckpointer()
+            out_class.state_neural_net = checkpointer.restore(
+                ckpt_path, item=out_class.state_neural_net
+            )
+            logger.info("Loaded ConditionalMongeTrainer from checkpoint")
+            return out_class
+        except:
+            logger.error(
+                "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
+            )
+            return

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -2,7 +2,7 @@ import collections
 import functools
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Iterator, Optional, Tuple
+from typing import Callable, Dict, Iterator, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -356,7 +356,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
         config: DotMap,
         datamodule: ConditionalDataModule,
         ckpt_path: Path,
-    ) -> Union[ConditionalMongeTrainer, None]:
+    ) -> Union[AbstractTrainer, None]:
         try:
             out_class = cls(
                 jobid=jobid,

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -356,7 +356,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
         config: DotMap,
         datamodule: ConditionalDataModule,
         ckpt_path: Path,
-    ) -> None:
+    ) -> Union[ConditionalMongeTrainer, None]:
         try:
             out_class = cls(
                 jobid=jobid,
@@ -369,17 +369,15 @@ class ConditionalMongeTrainer(AbstractTrainer):
                     ckpt_path = config.checkpointing_path
                 else:
                     logger.error(
-                        """Provide checkpointing path either directly or
-                        through the model config"""
+                        "Provide checkpointing path either directly or through the model config"
                     )
-                    return
             checkpointer = PyTreeCheckpointer()
             out_class.state_neural_net = checkpointer.restore(
                 ckpt_path, item=out_class.state_neural_net
             )
             logger.info("Loaded ConditionalMongeTrainer from checkpoint")
             return out_class
-        except:
+        except Exception:
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -328,10 +328,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
     def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
         if path is None and config is None:
-            logger.error(
-                """Please provide a checkpoint save path
-            either directly or through the config, checkpoint was NOT saved."""
-            )
+            logger.error("Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved.")
         elif path is None:
             path = config.checkpointing_path
 

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -370,4 +370,3 @@ class ConditionalMongeTrainer(AbstractTrainer):
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )
-            return

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -4,17 +4,10 @@ from functools import partial
 from pathlib import Path
 from typing import Callable, Dict, Iterator, Optional, Tuple, Union
 
+import flax.linen as nn
 import jax
 import jax.numpy as jnp
 import optax
-from dotmap import DotMap
-from flax.core import frozen_dict
-from flax.training import train_state
-from flax.training.orbax_utils import save_args_from_target
-from jax.tree_util import tree_map
-from loguru import logger
-from orbax.checkpoint import PyTreeCheckpointer
-
 from cmonge.datasets.conditional_loader import ConditionalDataModule
 from cmonge.evaluate import init_logger_dict, log_mean_metrics, log_metrics
 from cmonge.models.embedding import BaseEmbedding, EmbeddingFactory
@@ -25,6 +18,13 @@ from cmonge.trainers.ot_trainer import (
     regularizer_factory,
 )
 from cmonge.utils import create_or_update_logfile, optim_factory
+from dotmap import DotMap
+from flax.core import frozen_dict
+from flax.training import train_state
+from flax.training.orbax_utils import save_args_from_target
+from jax.tree_util import tree_map
+from loguru import logger
+from orbax.checkpoint import PyTreeCheckpointer
 
 
 class ConditionalMongeTrainer(AbstractTrainer):
@@ -48,9 +48,9 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
         self.dose_split = self.config.embedding.get("dose_split", True)
 
-        self.init_model(datamodule=datamodule)
+        self.setup(datamodule=datamodule)
 
-    def init_model(self, datamodule: ConditionalDataModule):
+    def setup(self, datamodule: ConditionalDataModule):
         # setup loss function and regularizer
         fitting_loss_fn = loss_factory[self.config.fitting_loss.name]
         regularizer_fn = regularizer_factory[self.config.regularizer.name]
@@ -334,49 +334,11 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
         create_or_update_logfile(self.logger_path, self.metrics)
 
-    def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
-        if path is None and config is None:
-            logger.error(
-                "Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved."
-            )
-        elif path is None:
-            path = config.checkpointing_path
+    @property
+    def model(self) -> nn.Module:
+        return self.state_neural_net
 
-        ckpt = self.state_neural_net
-        checkpointer = PyTreeCheckpointer()
-        save_args = save_args_from_target(ckpt)
-        checkpointer.save(path, ckpt, save_args=save_args, force=True)
-
-    @classmethod
-    def load_checkpoint(
-        cls,
-        jobid: int,
-        logger_path: Path,
-        config: DotMap,
-        datamodule: ConditionalDataModule,
-        ckpt_path: Path,
-    ) -> Union[AbstractTrainer, None]:
-        try:
-            out_class = cls(
-                jobid=jobid,
-                logger_path=logger_path,
-                config=config,
-                datamodule=datamodule,
-            )
-            if ckpt_path is None:
-                if len(config.checkpointing_path) > 0:
-                    ckpt_path = config.checkpointing_path
-                else:
-                    logger.error(
-                        "Provide checkpointing path either directly or through the model config"
-                    )
-            checkpointer = PyTreeCheckpointer()
-            out_class.state_neural_net = checkpointer.restore(
-                ckpt_path, item=out_class.state_neural_net
-            )
-            logger.info("Loaded ConditionalMongeTrainer from checkpoint")
-            return out_class
-        except Exception:
-            logger.error(
-                "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
-            )
+    @model.setter
+    def model(self, value: nn.Module):
+        """Setter for the model to be checkpointed."""
+        self.state_neural_net = value

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -46,7 +46,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
         self.regularizer_strength = 1
         self.num_train_iters = self.config.num_train_iters
         self.grad_acc_steps = self.config.optim.get("grad_acc_steps", 1)
-        self.init_model(datamodule=datamodule)
+        self.setup(datamodule=datamodule)
 
     def setup(self, datamodule: ConditionalDataModule):
         """

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -2,7 +2,7 @@ import collections
 import functools
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, Iterator, Optional, Tuple
+from typing import Callable, Dict, Iterator, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
@@ -348,7 +348,7 @@ class ConditionalMongeTrainer(AbstractTrainer):
         config: DotMap,
         datamodule: ConditionalDataModule,
         ckpt_path: Path,
-    ) -> Union[ConditionalMongeTrainer, None]:
+    ) -> Union[AbstractTrainer, None]:
         try:
             out_class = cls(
                 jobid=jobid,

--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -328,7 +328,9 @@ class ConditionalMongeTrainer(AbstractTrainer):
 
     def save_checkpoint(self, path: Path, config: DotMap = None) -> None:
         if path is None and config is None:
-            logger.error("Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved.")
+            logger.error(
+                "Please provide a checkpoint save path either directly or through the config, checkpoint was NOT saved."
+            )
         elif path is None:
             path = config.checkpointing_path
 

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -183,7 +183,7 @@ class MongeMapTrainer(AbstractTrainer):
         if path is None and config is None:
             logger.error(
                 """Please provide a checkpoint save path
-            either directly or through the config"""
+            either directly or through the config, checkpoint was NOT saved."""
             )
         elif path is None:
             path = config.checkpointing_path
@@ -201,28 +201,35 @@ class MongeMapTrainer(AbstractTrainer):
         config: DotMap,
         ckpt_path: Path = None,
     ) -> None:
-        out_class = cls(
-            jobid=jobid,
-            logger_path=logger_path,
-            config=config,
-        )
 
-        if ckpt_path is None:
-            if len(config.checkpointing_path) > 0:
-                ckpt_path = config.checkpointing_path
-            else:
-                logger.error(
-                    """Provide checkpointing path either directly or
-                    through the model config"""
-                )
+        try:
+            out_class = cls(
+                jobid=jobid,
+                logger_path=logger_path,
+                config=config,
+            )
 
-        checkpointer = PyTreeCheckpointer()
-        out_class.solver.state_neural_net = checkpointer.restore(
-            ckpt_path, item=out_class.solver.state_neural_net
-        )
-        out_class.state = out_class.solver.state_neural_net
-        logger.info("Loaded MongeMapTrainer from checkpoint")
-        return out_class
+            if ckpt_path is None:
+                if len(config.checkpointing_path) > 0:
+                    ckpt_path = config.checkpointing_path
+                else:
+                    logger.error(
+                        """Provide checkpointing path either directly or
+                        through the model config"""
+                    )
+                    return
+            checkpointer = PyTreeCheckpointer()
+            out_class.solver.state_neural_net = checkpointer.restore(
+                ckpt_path, item=out_class.solver.state_neural_net
+            )
+            out_class.state = out_class.solver.state_neural_net
+            logger.info("Loaded MongeMapTrainer from checkpoint")
+            return out_class
+        except:
+            logger.error(
+                "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
+            )
+            return
 
 
 class NeuralDualTrainer(AbstractTrainer):

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -179,7 +179,7 @@ class MongeMapTrainer(AbstractTrainer):
         """Transports a batch of data using the learned model."""
         return self.state.apply_fn({"params": self.state.params}, source)
 
-def save_checkpoint(self, path: Path = None, config: DotMap = None) -> None:
+    def save_checkpoint(self, path: Path = None, config: DotMap = None) -> None:
         if path is None and config is None:
             logger.error(
                 """Please provide a checkpoint save path

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -200,7 +200,7 @@ class MongeMapTrainer(AbstractTrainer):
         logger_path: Path,
         config: DotMap,
         ckpt_path: Path = None,
-    ) -> None:
+    ) -> Union[MongeMapTrainer, None]:
 
         try:
             out_class = cls(
@@ -214,10 +214,8 @@ class MongeMapTrainer(AbstractTrainer):
                     ckpt_path = config.checkpointing_path
                 else:
                     logger.error(
-                        """Provide checkpointing path either directly or
-                        through the model config"""
+                        "Provide checkpointing path either directly or through the model config"
                     )
-                    return
             checkpointer = PyTreeCheckpointer()
             out_class.solver.state_neural_net = checkpointer.restore(
                 ckpt_path, item=out_class.solver.state_neural_net
@@ -225,7 +223,7 @@ class MongeMapTrainer(AbstractTrainer):
             out_class.state = out_class.solver.state_neural_net
             logger.info("Loaded MongeMapTrainer from checkpoint")
             return out_class
-        except:
+        except Exception:
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -94,7 +94,6 @@ class AbstractTrainer(abc.ABC):
         **kwargs,
     ) -> T:
         try:
-            # TODO: Does this work for every base class?
             out_class = cls(
                 jobid=jobid, logger_path=logger_path, config=config, *args, **kwargs
             )

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -7,12 +7,12 @@ import jax.numpy as jnp
 import optax
 from dotmap import DotMap
 from flax import linen as nn
-from jax.lib import xla_bridge
 from flax.training.orbax_utils import save_args_from_target
+from jax.lib import xla_bridge
 from loguru import logger
+from orbax.checkpoint import PyTreeCheckpointer
 from ott.solvers.nn import models, neuraldual
 from ott.tools import map_estimator
-from orbax.checkpoint import PyTreeCheckpointer
 
 from cmonge.datasets.single_loader import AbstractDataModule
 from cmonge.evaluate import (

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -133,7 +133,7 @@ class AbstractTrainer(abc.ABC):
             checkpointer = PyTreeCheckpointer()
             out_class.model = checkpointer.restore(ckpt_path, item=out_class.model)
 
-            logger.info("Loaded MongeMapTrainer from checkpoint")
+            logger.info("Loaded model from checkpoint")
             return out_class
         except Exception as e:
             raise Exception(

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -229,7 +229,6 @@ class MongeMapTrainer(AbstractTrainer):
             logger.error(
                 "Failed to load checkpoint, are you sure checkpoint was saved and correct path is provided?"
             )
-            return
 
 
 class NeuralDualTrainer(AbstractTrainer):

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -90,13 +90,13 @@ class AbstractTrainer(abc.ABC):
         logger_path: Path,
         config: DotMap,
         ckpt_path: Path = None,
+        *args,
+        **kwargs,
     ) -> T:
         try:
             # TODO: Does this work for every base class?
             out_class = cls(
-                jobid=jobid,
-                logger_path=logger_path,
-                config=config,
+                jobid=jobid, logger_path=logger_path, config=config, *args, **kwargs
             )
 
             if ckpt_path is None:

--- a/cmonge/trainers/ot_trainer.py
+++ b/cmonge/trainers/ot_trainer.py
@@ -1,16 +1,18 @@
 import abc
 from functools import partial
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import jax.numpy as jnp
 import optax
 from dotmap import DotMap
 from flax import linen as nn
 from jax.lib import xla_bridge
+from flax.training.orbax_utils import save_args_from_target
 from loguru import logger
 from ott.solvers.nn import models, neuraldual
 from ott.tools import map_estimator
+from orbax.checkpoint import PyTreeCheckpointer
 
 from cmonge.datasets.single_loader import AbstractDataModule
 from cmonge.evaluate import (
@@ -200,7 +202,7 @@ class MongeMapTrainer(AbstractTrainer):
         logger_path: Path,
         config: DotMap,
         ckpt_path: Path = None,
-    ) -> Union[MongeMapTrainer, None]:
+    ) -> Union[AbstractTrainer, None]:
 
         try:
             out_class = cls(

--- a/cmonge/utils.py
+++ b/cmonge/utils.py
@@ -37,7 +37,7 @@ def get_source_target_transport(
     all_expr = []
     for condition in conditions:
         print(condition)
-        cond_embeddings = trainer.embedding_module(condition)
+        cond_embeddings, num_contexts = trainer.embedding_module(condition)
 
         if split_type == "valid":
             loader_source, loader_target = datamodule.valid_dataloaders()[condition]
@@ -64,7 +64,7 @@ def get_source_target_transport(
             all_expr.append(res_source)
 
         if transport:
-            trans = trainer.transport(source_expr, cond_embeddings)
+            trans = trainer.transport(source_expr, cond_embeddings, num_contexts)
             trans = datamodule.decoder(trans)
             trans = pd.DataFrame(trans)
             trans["dtype"] = "trans"


### PR DESCRIPTION
- checkpointing (loading and storing) now implemented in the abstract base class
- this is much easier and more efficient than copying the checkpointing logic for every trainer
- actual trainers have to implement the `model` function that specifies how to retrieve or set the attribute for checkpointing
- this could be further simplified by homogenizing the model names (MongeMap uses `self.solver.state_neural_net`, ICNN uses `self.neural_dual_solver` and CMonge uses `state_neural_net`) but I leave this for future PR to not fiddle too much with existing code
- when saving a checkpoint, the code actually raises if path and config are both not specified
- raises if checkpoint could not be loaded
- Side effect: ICNN trainer should support checkpointing now
