### PR TITLE
Update conditional_monge_trainer.py

### DIFF
--- a/cmonge/trainers/conditional_monge_trainer.py
+++ b/cmonge/trainers/conditional_monge_trainer.py
@@ -97,9 +97,9 @@ class ConditionalMongeTrainer(AbstractTrainer):
         split_type: str,
     ) -> Dict[str, jnp.ndarray]:
         """Generate a batch of condition and samples."""
-        condition_to_loaders = datamodule.get_loaders_by_type(split_type)
         condition = datamodule.sample_condition(split_type)
-        loader_source, loader_target = condition_to_loaders[condition]
+        loaders = datamodule.loaders[condition]
+        loader_source, loader_target = loaders.get_loaders_by_type(split_type)
         embeddings, n_contexts = self.embedding_module(condition=condition)
         return (
             {


### PR DESCRIPTION
Speeding up batch generation during training.

Before (45-50 s/it):
1. Set up all dataloaders for train/test/val `split_type`
2. Sample condition
3. Select dataloader from all dataloaders in step 1.

Now (3-4 s/it):
1. Sample condition
2. Get single loader for condition
3. Set up train/test/val dataloader for that condition